### PR TITLE
* fix java.lang.StringIndexOutOfBoundsException: begin 0, end 1, leng…

### DIFF
--- a/MiraiBot/src/main/java/com/kenvix/complexbot/ExtensionUtils.kt
+++ b/MiraiBot/src/main/java/com/kenvix/complexbot/ExtensionUtils.kt
@@ -32,8 +32,10 @@ fun MessagePacketSubscribersBuilder.command(command: String,
         commands = HashMap()
         this.always {
             val plainMsg = this.message.filterIsInstance<PlainText>().joinToString("").trim()
+            if (plainMsg.length < commandPrefixLength) {
+                return@always
+            }
             if (plainMsg.isNotEmpty() && plainMsg.substring(0, commandPrefixLength) in commandPrefix) {
-
                 executeCatchingBusinessException {
                     val requestedCommand = plainMsg.run {
                         val spacePos = this.indexOf(' ')


### PR DESCRIPTION
…th 0

      stdout
      05:41:55
      	at java.base/java.lang.String.checkBoundsBeginEnd(Unknown Source)
      stdout
      05:41:55
      	at java.base/java.lang.String.substring(Unknown Source)
      stdout
      05:41:55
      	at com.kenvix.complexbot.ExtensionUtilsKt$command$2.invokeSuspend(ExtensionUtils.kt:31)
      stdout
      05:41:55
      	at com.kenvix.complexbot.ExtensionUtilsKt$command$2.invoke(ExtensionUtils.kt)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.SubscribeMessagesKt__SubscribeMessagesKt$subscribeMessages$2$1.invokeSuspend(subscribeMessages.kt:61)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.SubscribeMessagesKt__SubscribeMessagesKt$subscribeMessages$2$1.invoke(subscribeMessages.kt)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.SubscriberKt__SubscriberKt$subscribeAlways$1.invokeSuspend(subscriber.kt:271)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.SubscriberKt__SubscriberKt$subscribeAlways$1.invoke(subscriber.kt)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.internal.Handler$onEvent$2.invokeSuspend(InternalEventListeners.kt:89)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.internal.Handler$onEvent$2.invoke(InternalEventListeners.kt)
      stdout
      05:41:55
      	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
      stdout
      05:41:55
      	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:160)
      stdout
      05:41:55
      	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.internal.Handler.onEvent(InternalEventListeners.kt:89)
      stdout
      05:41:55
      	at net.mamoe.mirai.event.internal.InternalEventListenersKt$callAndRemoveIfRequired$3$invokeSuspend$$inlined$forEachNode$lambda$1.invokeSuspend(InternalEventListeners.kt:180)
      stdout
      05:41:55
      	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
      stdout
      05:41:55
      	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
      stdout
      05:41:55
      	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
      stdout
      05:41:55
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
      stdout
      05:41:55
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
      stdout
      05:41:55
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)