### PR TITLE
* fix backend connection failure will cause app hang

### DIFF
--- a/MiraiBot/src/main/java/com/kenvix/complexbot/ComplexBotDriver.kt
+++ b/MiraiBot/src/main/java/com/kenvix/complexbot/ComplexBotDriver.kt
@@ -156,7 +156,12 @@ class ComplexBotDriver : AbstractDriver<ComplexBotConfig>(), Cached {
         }
 
         backend = BackendConnector(BackendBridge.Client::class.java, backendHost, backendPort)
-        backend.connect()
+        try {
+            backend.connect()
+        } catch (t: Throwable) {
+            logger.error("Unable to connect to Backend", t)
+            System.exit(1)
+        }
     }
 
     internal suspend fun stopBackend() = withContext(IO) {


### PR DESCRIPTION
org.apache.thrift.transport.TTransportException: java.net.ConnectException: Connection refused (Connection refused)
      stdout
      07:25:43
      	at org.apache.thrift.transport.TSocket.open(TSocket.java:226)
      stdout
      07:25:43
      	at com.kenvix.moecraftbot.ng.lib.BackendConnector$connect$2.invokeSuspend(BackendConnector.kt:66)
      stdout
      07:25:43
      	at com.kenvix.moecraftbot.ng.lib.BackendConnector$connect$2.invoke(BackendConnector.kt)
      stdout
      07:25:43
      	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
      stdout
      07:25:43
      	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:160)
      stdout
      07:25:43
      	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
      stdout
      07:25:43
      	at com.kenvix.moecraftbot.ng.lib.BackendConnector.connect(BackendConnector.kt:49)
      stdout
      07:25:43
      	at com.kenvix.moecraftbot.ng.lib.BackendConnector.connect$default(BackendConnector.kt:49)
      stdout
      07:25:43
      	at com.kenvix.complexbot.ComplexBotDriver$loadBackend$2.invokeSuspend(ComplexBotDriver.kt:151)
      stdout
      07:25:43
      	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
      stdout
      07:25:43
      	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
      stdout
      07:25:43
      	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
      stdout
      07:25:43
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
      stdout
      07:25:43
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
      stdout
      07:25:43
      	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
      stdout
      07:25:43
      Caused by: java.net.ConnectException: Connection refused (Connection refused)
      stdout
      07:25:43
      	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
      stdout
      07:25:43
      	at java.base/java.net.AbstractPlainSocketImpl.doConnect(Unknown Source)
      stdout
      07:25:43
      	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(Unknown Source)
      stdout
      07:25:43
      	at java.base/java.net.AbstractPlainSocketImpl.connect(Unknown Source)
      stdout
      07:25:43
      	at java.base/java.net.SocksSocketImpl.connect(Unknown Source)
      stdout
      07:25:43
      	at java.base/java.net.Socket.connect(Unknown Source)
      stdout
      07:25:43
      	at org.apache.thrift.transport.TSocket.open(TSocket.java:221)
      stdout
      07:25:43
      	... 14 common frames omitted